### PR TITLE
Add NSF NCAR example

### DIFF
--- a/examples/ncar/derecho/ncar_derecho_config
+++ b/examples/ncar/derecho/ncar_derecho_config
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Author: Daniel Howard, NSF NCAR (dhoward)
+
+# Load required modules (including correct CPU and GPU target modules)
+ml ncarenv/24.12
+ml reset
+ml gcc/12.4.0
+ml cuda/12.3.2
+ml swap hdf5 hdf5-mpi/1.12.3 
+module list
+
+# Environment variables for HPC key packages that require system libraries that require system libraries (MPI.jl, CUDA.jl, AMDGPU.jl, HDF5.jl and ADIOS2.jl)
+export JUHPC_CUDA_HOME=$CUDA_HOME
+export JUHPC_CUDA_RUNTIME_VERSION=$CRAY_CUDATOOLKIT_VERSION
+export JUHPC_MPI_VENDOR="cray"
+export JUHPC_MPI_EXEC="mpiexec"
+export JUHPC_HDF5_HOME=$NCAR_ROOT_HDF5
+
+# Call JUHPC
+JUHPC_SETUP_INSTALLDIR=/glade/u/apps/opt/julia/$NCAR_HOST/juhpc_setup
+JULIAUP_INSTALLDIR="/glade/work/\$USER/julia/\$NCAR_HOST/juliaup"
+VERSION="v0.3.0"
+#wget https://raw.githubusercontent.com/JuliaParallel/JUHPC/$VERSION/juhpc -O ./juhpc
+./juhpc $JUHPC_SETUP_INSTALLDIR $JULIAUP_INSTALLDIR --verbose=2 | tee juhpc_install.log

--- a/examples/ncar/derecho/test_ncar_derecho_config
+++ b/examples/ncar/derecho/test_ncar_derecho_config
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# Load required modules (including correct CPU and GPU target modules)
+ml ncarenv/24.12
+ml reset
+ml gcc/12.4.0
+ml cuda/12.3.2
+ml swap hdf5 hdf5-mpi/1.12.3 
+module list
+
+# Call JUHPC
+JUHPC_SETUP_INSTALLDIR=/glade/u/apps/opt/julia/$NCAR_HOST/juhpc_setup
+
+# Activate the HPC setup environment variables
+. $JUHPC_SETUP_INSTALLDIR/activate
+
+# Call juliaup to install juliaup and latest julia on scratch
+juliaup
+
+# Call juliaup to see its options
+juliaup
+
+# Call julia Pkg 
+julia -e 'using Pkg; Pkg.status()'
+
+# Add CUDA.jl
+julia -e 'using Pkg; Pkg.add("CUDA"); using CUDA; CUDA.versioninfo()'
+
+# Add MPI.jl
+julia -e 'using Pkg; Pkg.add("MPI"); using MPI; MPI.versioninfo()'
+
+# Add HDF5.jl
+julia -e 'using Pkg; Pkg.add("HDF5"); using HDF5; @show HDF5.has_parallel()'

--- a/juhpc
+++ b/juhpc
@@ -303,7 +303,8 @@ info "... done: wrapper created."
 info "Creating activate script..."
 
 export JULIAUP_DEPOT="$JULIAUP_INSTALLDIR/depot"
-export JULIA_DEPOT="$JULIAUP_INSTALLDIR/depot"
+# Added default $HOME/.julia path for backwards compatibility with exisitng Julia user installs
+export JULIA_DEPOT="$JULIAUP_INSTALLDIR/depot:$HOME/.julia"
 export ACTIVATE_SCRIPT="$JUHPC_SETUP_INSTALLDIR/activate"
 
 julia -e 'println("""

--- a/juhpc
+++ b/juhpc
@@ -143,7 +143,9 @@ fi
 
 export JULIAUP_BINDIR="$JULIAUP_INSTALLDIR/bin" # juliaup and julia binaries
 
-if [ -d "/dev/shm" ]; then
+if [ ! -z "$NCAR_HOST"]; then
+	export TMP="$SCRATCH/tmp"
+elif [ -d "/dev/shm" ]; then
     export TMP="/dev/shm/$USER"
 elif [ -d "/tmp" ]; then
     export TMP="/tmp/$USER"


### PR DESCRIPTION
Primarily added example for Derecho install at NCAR.

Only other change was setting TMP directory to NCAR scratch (our scratch purges) though the solution might be applied differently for general future users.

I also made the choice to have a central JUHPC_SETUP directory with then the JULIAUP_INSTALLDIR targeting user directories. To be further tested and finalized for our user community soon.